### PR TITLE
Only handle tab key inside of editor

### DIFF
--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -60,7 +60,7 @@ angular.module('app.frontend')
               }
           }
         };
-	
+
         window.addEventListener('keydown', handler);
         var element = document.getElementById("note-text-editor");
         element.addEventListener('keydown', handleTab);

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -19,8 +19,7 @@ angular.module('app.frontend')
          * Insert 4 spaces when a tab key is pressed, 
          * only used when inside of the text editor.
          */
-        var handleTab = function (event ) {
-
+        var handleTab = function (event) {
           if (event.which == 9) {
             event.preventDefault();
             var start = event.target.selectionStart;

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -61,9 +61,8 @@ angular.module('app.frontend')
           }
         };
 
-        window.addEventListener('keydown', handler);
-        var editor = document.getElementById("note-text-editor");
-        editor.addEventListener('keydown', handleTab);
+        var element = document.getElementById("note-text-editor");
+        element.addEventListener('keydown', handleTab);
 
 
         scope.$on('$destroy', function(){
@@ -109,7 +108,8 @@ angular.module('app.frontend')
 
     this.focusEditor = function(delay) {
       setTimeout(function(){
-        editor.focus();
+        var element = document.getElementById("note-text-editor");
+        element.focus();
       }, delay)
     }
 

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -60,11 +60,10 @@ angular.module('app.frontend')
               }
           }
         };
-
+	
 	window.addEventListener('keydown', handler);
-        var element = document.getElementById("note-text-editor");
-        element.addEventListener('keydown', handleTab);
-
+	var element = document.getElementById("note-text-editor");
+	element.addEventListener('keydown', handleTab);
 
         scope.$on('$destroy', function(){
           window.removeEventListener('keydown', handler);

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -61,6 +61,7 @@ angular.module('app.frontend')
           }
         };
 
+	window.addEventListener('keydown', handler);
         var element = document.getElementById("note-text-editor");
         element.addEventListener('keydown', handleTab);
 

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -61,9 +61,9 @@ angular.module('app.frontend')
           }
         };
 	
-	window.addEventListener('keydown', handler);
-	var element = document.getElementById("note-text-editor");
-	element.addEventListener('keydown', handleTab);
+        window.addEventListener('keydown', handler);
+        var element = document.getElementById("note-text-editor");
+        element.addEventListener('keydown', handleTab);
 
         scope.$on('$destroy', function(){
           window.removeEventListener('keydown', handler);

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -15,16 +15,23 @@ angular.module('app.frontend')
 
       link:function(scope, elem, attrs, ctrl) {
 
+        /**
+         * Insert 4 spaces when a tab key is pressed, 
+         * only used when inside of the text editor.
+         */
+        var handleTab = function (event ) {
+
+          if (event.which == 9) {
+            event.preventDefault();
+            var start = event.target.selectionStart;
+            var end = event.target.selectionEnd;
+            var spaces = "    ";
+            event.target.value = event.target.value.substring(0, start)
+              + spaces + event.target.value.substring(end);
+          }
+        }
+
         var handler = function(event) {
-      	  // Handle Tab Key
-      	  if (event.which == 9) {
-      	      event.preventDefault();
-      	      var start = event.target.selectionStart;
-      	      var end = event.target.selectionEnd;
-      	      var spaces = "    ";
-      	      event.target.value = event.target.value.substring(0, start)
-                        + spaces + event.target.value.substring(end);
-      	  }
           if (event.ctrlKey || event.metaKey) {
               switch (String.fromCharCode(event.which).toLowerCase()) {
               case 's':
@@ -56,6 +63,9 @@ angular.module('app.frontend')
         };
 
         window.addEventListener('keydown', handler);
+        var editor = document.getElementById("note-text-editor");
+        editor.addEventListener('keydown', handleTab);
+
 
         scope.$on('$destroy', function(){
           window.removeEventListener('keydown', handler);
@@ -100,8 +110,7 @@ angular.module('app.frontend')
 
     this.focusEditor = function(delay) {
       setTimeout(function(){
-        var element = document.getElementById("note-text-editor");
-        element.focus();
+        editor.focus();
       }, delay)
     }
 


### PR DESCRIPTION
This refactors the controller a bit to insert 4 spaces when
a tab key is inserted inside of an editor, but in all other parts
of the app allow the user to use the tab key normally.

fix
https://github.com/standardnotes/desktop/issues/23