### PR TITLE
change undefined titles to empty string

### DIFF
--- a/app/assets/javascripts/app/services/modelManager.js
+++ b/app/assets/javascripts/app/services/modelManager.js
@@ -112,14 +112,17 @@ class ModelManager {
   }
 
   addItems(items) {
+    _.each(items, function(item){
+      if (!(item.title)) item.title = '';
+    });
+
     this.items = _.uniq(this.items.concat(items));
 
     items.forEach(function(item){
       if(item.content_type == "Tag") {
         if(!_.find(this.tags, {uuid: item.uuid})) {
           this.tags.splice(_.sortedIndexBy(this.tags, item, function(item){
-            if (item.title) return item.title.toLowerCase();
-            else return ''
+            return item.title.toLowerCase();
           }), 0, item);
         }
       } else if(item.content_type == "Note") {


### PR DESCRIPTION
When a user creates a new tag with empty title, ensure the title's value is set to empty string `''` instead of  `undefined`.