### PR TITLE
Reset the cursor

### DIFF
--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -23,11 +23,17 @@ angular.module('app.frontend')
         var handleTab = function (event) {
           if (event.which == 9) {
             event.preventDefault();
-            var start = event.target.selectionStart;
-            var end = event.target.selectionEnd;
+            var start = this.selectionStart;
+            var end = this.selectionEnd;
             var spaces = "    ";
-            event.target.value = event.target.value.substring(0, start)
-              + spaces + event.target.value.substring(end);
+
+	    // Insert 4 spaces
+            this.value = this.value.substring(0, start)
+              + spaces + this.value.substring(end);
+
+	    // Place cursor 4 spaces away from where
+	    // the tab key was pressed
+	    this.selectionStart = this.selectionEnd = start + 4;
           }
         }
 

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -19,9 +19,11 @@ angular.module('app.frontend')
         /**
          * Insert 4 spaces when a tab key is pressed,
          * only used when inside of the text editor.
+	 * If the shift key is pressed first, this event is
+	 * not fired. 
          */
         var handleTab = function (event) {
-          if (event.which == 9) {
+	  if (!event.shiftKey && event.which == 9) {
             event.preventDefault();
             var start = this.selectionStart;
             var end = this.selectionEnd;

--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -23,7 +23,7 @@ angular.module('app.frontend')
 	 * not fired. 
          */
         var handleTab = function (event) {
-	  if (!event.shiftKey && event.which == 9) {
+          if (!event.shiftKey && event.which == 9) {
             event.preventDefault();
             var start = this.selectionStart;
             var end = this.selectionEnd;


### PR DESCRIPTION
Once tab key is pressed, place the cursor 4 spaces away from
the location where the tab key was pressed.

This handles the case of when a tab key is pressed in the middle of
an existing note and the cursor was placed at the end of the document.

fix https://github.com/standardnotes/web/issues/50