### PR TITLE
Set preview mode as default

### DIFF
--- a/app/assets/javascripts/app/frontend/controllers/editor.js
+++ b/app/assets/javascripts/app/frontend/controllers/editor.js
@@ -91,7 +91,8 @@ angular.module('app.frontend')
   .controller('EditorCtrl', function ($sce, $timeout, apiController, markdownRenderer, $rootScope, extensionManager) {
 
     this.setNote = function(note, oldNote) {
-      this.editorMode = 'edit';
+      var isNewNote = note.dummy
+      this.editorMode =  isNewNote ? 'edit' : 'preview';
       this.showExtensions = false;
       this.showMenu = false;
       this.loadTagsString();


### PR DESCRIPTION
## Current scenario
Default editor mode is 'edit' for notes.

## Fix done
After a note is created, the default mode of the editor is now set to preview.
For new note, the default mode is edit.

fix #31 