### PR TITLE
Show 'Offline' in bottom right of header when offline

### DIFF
--- a/app/assets/javascripts/app/frontend/controllers/header.js
+++ b/app/assets/javascripts/app/frontend/controllers/header.js
@@ -129,8 +129,10 @@ angular.module('app.frontend')
           this.isRefreshing = false;
         }.bind(this), 200)
         if(response && response.error) {
+          this.isOffline = true
           alert("There was an error syncing. Please try again. If all else fails, log out and log back in.");
         } else {
+          this.isOffline = false
           this.syncUpdated();
         }
       }.bind(this));

--- a/app/assets/stylesheets/app/_header.scss
+++ b/app/assets/stylesheets/app/_header.scss
@@ -65,6 +65,10 @@
        color: #515263;
      }
 
+     &.offline {
+       color : red;
+     }
+
      .panel {
        position: absolute;
        right: 0px;

--- a/app/assets/templates/frontend/header.html.haml
+++ b/app/assets/templates/frontend/header.html.haml
@@ -168,3 +168,5 @@
             .spinner
         .item{"ng-click" => "ctrl.refreshData()"}
           Refresh
+        .item.offline{"ng-if" => "ctrl.isOffline"}
+          Offline


### PR DESCRIPTION
For a signed in user, the 'offline' text will appear in the header for 2 cases:
1. The user clicks the 'Refresh' button in the header and the server is unreachable.
2. The user is typing the note in the editor, the autosave fails as the server is unreachable, hence the note status shows '(Offline) — All changes saved'.

**This PR has the case 1.**

For case 2, I am stuck and need help.
- While editing the note, if remote server is unreachable, the note status says [this](https://github.com/standardnotes/web/blob/master/app/assets/javascripts/app/frontend/controllers/editor.js#L158)
I am wondering, how I can set the isOffline boolean in HeaderCtrl from EditorCtrl.
- I tried to add a 'offlineManager' service that will have isOffline flag and then inject this service in HeaderCtrl and EditorCtrl.
But if EditorCtrl changes the flag when offline, then the header have to know it without checking the flag explicitly.

Please suggest what should be the right way in this case.

