### PR TITLE
Clear New Theme URL after submit

### DIFF
--- a/app/assets/javascripts/app/services/directives/views/globalExtensionsMenu.js
+++ b/app/assets/javascripts/app/services/directives/views/globalExtensionsMenu.js
@@ -69,6 +69,7 @@ class GlobalExtensionsMenu {
 
     $scope.submitTheme = function() {
       themeManager.submitTheme($scope.state.themeUrl);
+      $scope.state.themeUrl = "";
     }
 
     $scope.deleteTheme = function(theme) {


### PR DESCRIPTION
This commit clears the "New Theme URL" after submitting the form in the same way that it is done for adding a new editor via URL.