### PR TITLE
Remove dead code for installing new editors

### DIFF
--- a/app/assets/javascripts/app/services/directives/views/globalExtensionsMenu.js
+++ b/app/assets/javascripts/app/services/directives/views/globalExtensionsMenu.js
@@ -170,8 +170,6 @@ class GlobalExtensionsMenu {
 
         if(type == "sf") {
           $scope.handleSyncAdapterLink(link, completion);
-        } else if(type == "editor") {
-          $scope.handleEditorLink(link, completion);
         } else if(link.indexOf(".css") != -1 || type == "theme") {
           $scope.handleThemeLink(link, completion);
         } else if(type == "component") {


### PR DESCRIPTION
Thanks for doing Standard Notes! I noticed `handleEditorLink` isn't defined and the proper way of setting editors is a Component with area editor-editor, so I think this code is dead and can be removed.