### PR TITLE
Fixes #183: In tag views, only display other tags on notes;

### DIFF
--- a/app/assets/javascripts/app/controllers/notes.js
+++ b/app/assets/javascripts/app/controllers/notes.js
@@ -271,4 +271,14 @@ angular.module('app')
       return note.tags && note.tags.length > 1;
     }
 
+    this.getTagsString = function(note) {
+      var tags;
+      if(this.tag.all) {
+        tags = note.tags;
+      } else {
+        tags = note.tags.filter(tag => tag.uuid !== this.tag.uuid);
+      }
+      return Tag.arrayToDisplayString(tags);
+    }
+
   });

--- a/app/assets/javascripts/app/models/app/note.js
+++ b/app/assets/javascripts/app/models/app/note.js
@@ -108,7 +108,7 @@ class Note extends Item {
   }
 
   toJSON() {
-    return {uuid: this.uuid}
+    return {uuid: this.uuid};
   }
 
   get content_type() {

--- a/app/assets/templates/notes.html.haml
+++ b/app/assets/templates/notes.html.haml
@@ -55,7 +55,7 @@
             %strong.medium Archived
 
           .tags-string{"ng-if" => "ctrl.shouldShowTags(note)"}
-            .faded {{note.savedTagsString || note.tagsString()}}
+            .faded {{ ctrl.getTagsString(note) }}
 
           .name{"ng-if" => "note.title"}
             {{note.title}}


### PR DESCRIPTION
I didn't see a lot of ES6 code, so I assumed babel wasn't used, so the code I introduced is very conservative with ES features, let me know if you'd prefer something else.

Can you have a look please, @mobitar ? Thanks!