### PR TITLE
fix(app/assets): Make some buttons focusable

### DIFF
--- a/app/assets/stylesheets/app/_main.scss
+++ b/app/assets/stylesheets/app/_main.scss
@@ -170,6 +170,7 @@ $footer-height: 32px;
          border-radius: 4px;
          font-weight: normal;
          text-align: center;
+         border: none;
 
          &:hover {
            background-color: darken($button-bg, 5%);

--- a/app/assets/stylesheets/app/_menus.scss
+++ b/app/assets/stylesheets/app/_menus.scss
@@ -1,6 +1,8 @@
 .app-bar {
   .item {
     position: relative;
+    background: inherit;
+    border: none;
   }
 }
 

--- a/app/assets/stylesheets/app/_tags.scss
+++ b/app/assets/stylesheets/app/_tags.scss
@@ -52,6 +52,9 @@
     transition: height .1s ease-in-out;
     position: relative;
     font-size: 14px;
+    background: inherit;
+    border: none;
+    text-align: start;
 
     > .info {
       height: 20px;

--- a/app/assets/templates/directives/account-menu.html.haml
+++ b/app/assets/templates/directives/account-menu.html.haml
@@ -2,7 +2,7 @@
   .panel#account-panel
     .header
       %h1.title Account
-      %a.close-button{"ng-click" => "close()"} Close
+      %a.close-button{"ng-click" => "close()", "href" => "#"} Close
     .content
 
       .panel-section.hero{"ng-if" => "!user && !formData.showLogin && !formData.showRegister && !formData.mfa"}
@@ -10,9 +10,9 @@
         .panel-row
         .panel-row
           .button-group.stretch
-            .button.info.featured{"ng-click" => "formData.showLogin = true"}
+            %button.button.info.featured{"ng-click" => "formData.showLogin = true"}
               .label Sign In
-            .button.info.featured{"ng-click" => "formData.showRegister = true"}
+            %button.button.info.featured{"ng-click" => "formData.showRegister = true"}
               .label Register
         %p
           Standard Notes is free on every platform, and comes standard with sync and encryption.
@@ -26,7 +26,7 @@
           %input{:placeholder => 'Password', :name => 'password', :required => true, :type => 'password', 'ng-model' => 'formData.user_password'}
           %input{:placeholder => 'Confirm Password', "ng-if" => "formData.showRegister", :name => 'password', :required => true, :type => 'password', 'ng-model' => 'formData.password_conf'}
 
-          %a.panel-row{"ng-click" => "formData.showAdvanced = !formData.showAdvanced"}
+          %a.panel-row{"ng-click" => "formData.showAdvanced = !formData.showAdvanced", "href" => "#"}
             Advanced Options
           .notification.info{"ng-if" => "formData.showRegister"}
             %h2.title No Password Reset.
@@ -74,7 +74,7 @@
 
           .panel-row
 
-          %a.panel-row.condensed{"ng-click" => "newPasswordData.changePassword = !newPasswordData.changePassword"} Change Password
+          %a.panel-row.condensed{"ng-click" => "newPasswordData.changePassword = !newPasswordData.changePassword", "href" => "#"} Change Password
           .notification.warning{"ng-if" => "newPasswordData.changePassword"}
             %h1.title Change Password
             .text
@@ -84,27 +84,27 @@
               %p.bold It is highly recommended you download a backup of your data before proceeding.
             .panel-row{"ng-if" => "!newPasswordData.status"}
               .horizontal-group{"ng-if" => "!newPasswordData.showForm"}
-                %a.red{"ng-click" => "showPasswordChangeForm()"} Continue
-                %a{"ng-click" => "newPasswordData.changePassword = false; newPasswordData.showForm = false"} Cancel
+                %a.red{"ng-click" => "showPasswordChangeForm()", "href" => "#"} Continue
+                %a{"ng-click" => "newPasswordData.changePassword = false; newPasswordData.showForm = false", "href" => "#"} Cancel
               .panel-row{"ng-if" => "newPasswordData.showForm"}
                 %form.panel-form.stretch
                   %input{:type => 'password', "ng-model" => "newPasswordData.newPassword", "placeholder" => "Enter new password"}
                   %input{:type => 'password', "ng-model" => "newPasswordData.newPasswordConfirmation", "placeholder" => "Confirm new password"}
                   .button-group.stretch.panel-row.form-submit
-                    .button.info{"type" => "submit", "ng-click" => "submitPasswordChange()"}
+                    %button.button.info{"type" => "submit", "ng-click" => "submitPasswordChange()"}
                       .label Submit
-                  %a{"ng-click" => "newPasswordData.changePassword = false; newPasswordData.showForm = false"} Cancel
+                  %a{"ng-click" => "newPasswordData.changePassword = false; newPasswordData.showForm = false", "href" => "#"} Cancel
 
             %p.italic.mt-10{"ng-if" => "newPasswordData.status"} {{newPasswordData.status}}
 
 
 
-          %a.panel-row.condensed{"ng-click" => "showAdvanced = !showAdvanced"} Advanced
+          %a.panel-row.condensed{"ng-click" => "showAdvanced = !showAdvanced", "href" => "#"} Advanced
           %div{"ng-if" => "showAdvanced"}
-            %a.panel-row{"ng-click" => "reencryptPressed()"} Resync All Items
+            %a.panel-row{"ng-click" => "reencryptPressed()", "href" => "#"} Resync All Items
 
 
-          %a.panel-row.condensed{"ng-if" => "securityUpdateAvailable()", "ng-click" => "clickedSecurityUpdate()"} Security Update Available
+          %a.panel-row.condensed{"ng-if" => "securityUpdateAvailable()", "ng-click" => "clickedSecurityUpdate()", "href" => "#"} Security Update Available
           .notification.default{"ng-if" => "securityUpdateData.showForm"}
             %p
               %a{"href" => "https://standardnotes.org/help/security-update", "target" => "_blank"} Learn more.
@@ -129,7 +129,7 @@
           %h3.title.panel-row Passcode Lock
           %div{"ng-if" => "!hasPasscode()"}
             .panel-row{"ng-if" => "!formData.showPasscodeForm"}
-              .button.info{"ng-click" => "addPasscodeClicked(); $event.stopPropagation();"}
+              %button.button.info{"ng-click" => "addPasscodeClicked(); $event.stopPropagation();"}
                 .label Add Passcode
 
             %p Add an app passcode to lock the app and encrypt on-device key storage.
@@ -140,7 +140,7 @@
             .button-group.stretch.panel-row.form-submit
               %button.button.info{"type" => "submit"}
                 .label Set Passcode
-            %a.panel-row{"ng-click" => "formData.showPasscodeForm = false"} Cancel
+            %a.panel-row{"ng-click" => "formData.showPasscodeForm = false", "href" => "#"} Cancel
 
           %div{"ng-if" => "hasPasscode() && !formData.showPasscodeForm"}
             .panel-row
@@ -149,8 +149,8 @@
                 %span{"ng-if" => "isDesktopApplication()"} Your passcode will be required on new sessions after app quit.
             .panel-row.justify-left
               .horizontal-group
-                %a.info{"ng-click" => "changePasscodePressed()"} Change Passcode
-                %a.danger{"ng-click" => "removePasscodePressed()"} Remove Passcode
+                %a.info{"ng-click" => "changePasscodePressed()", "href" => "#"} Change Passcode
+                %a.danger{"ng-click" => "removePasscodePressed()", "href" => "#"} Remove Passcode
 
 
 
@@ -166,10 +166,10 @@
                 Decrypted
 
           .button-group
-            .button.info{"ng-click" => "downloadDataArchive()", "ng-class" => "{'mt-5' : !user}"}
+            %button.button.info{"ng-click" => "downloadDataArchive()", "ng-class" => "{'mt-5' : !user}"}
               .label Download Backup
 
-            %label.button.info
+            %button.button.info
               %input{"type" => "file", "style" => "display: none;", "file-change" => "->", "handler" => "importFileSelected(files)"}
               .label Import From Backup
 
@@ -183,7 +183,7 @@
           .panel-row
             .spinner.small.info{"ng-if" => "importData.loading"}
     .footer
-      %a.right{"ng-if" => "formData.showLogin || formData.showRegister", "ng-click" => "formData.showLogin = false; formData.showRegister = false;"}
+      %a.right{"ng-if" => "formData.showLogin || formData.showRegister", "ng-click" => "formData.showLogin = false; formData.showRegister = false;", "href" => "#"}
         Cancel
-      %a.right{"ng-if" => "!formData.showLogin && !formData.showRegister", "ng-click" => "destroyLocalData()"}
+      %a.right{"ng-if" => "!formData.showLogin && !formData.showRegister", "ng-click" => "destroyLocalData()", "href" => "#"}
         {{ user ? "Sign out and clear local data" : "Clear all local data" }}

--- a/app/assets/templates/directives/actions-menu.html.haml
+++ b/app/assets/templates/directives/actions-menu.html.haml
@@ -26,7 +26,7 @@
       .panel
         .header
           %h1.title Preview
-          %a.close-button.info{"ng-click" => "renderData.showRenderModal = false; $event.stopPropagation();"} Close
+          %a.close-button.info{"ng-click" => "renderData.showRenderModal = false; $event.stopPropagation();", "href" => "#"} Close
         .content.selectable
           %h2 {{renderData.title}}
           %p.normal{"style" => "white-space: pre-wrap; font-family: monospace; font-size: 16px;"} {{renderData.text}}

--- a/app/assets/templates/directives/component-modal.html.haml
+++ b/app/assets/templates/directives/component-modal.html.haml
@@ -6,5 +6,5 @@
       .header
         %h1.title
           {{component.name}}
-        %a.close-button.info{"ng-click" => "dismiss()"} Close
+        %a.close-button.info{"ng-click" => "dismiss()", "href" => "#"} Close
       %component-view.component-view{"component" => "component"}

--- a/app/assets/templates/directives/permissions-modal.html.haml
+++ b/app/assets/templates/directives/permissions-modal.html.haml
@@ -5,7 +5,7 @@
     .panel
       .header
         %h1.title Activate Extension
-        %a.close-button.info{"ng-click" => "deny()"} Cancel
+        %a.close-button.info{"ng-click" => "deny()", "href" => "#"} Cancel
       .content
         .panel-section
           .panel-row

--- a/app/assets/templates/editor.html.haml
+++ b/app/assets/templates/editor.html.haml
@@ -25,7 +25,7 @@
   .sn-component{"ng-if" => "ctrl.note"}
     .app-bar.no-edges
       .left
-        .item{"ng-click" => "ctrl.showMenu = !ctrl.showMenu; ctrl.showExtensions = false; ctrl.showEditorMenu = false;", "ng-class" => "{'selected' : ctrl.showMenu}", "click-outside" => "ctrl.showMenu = false;", "is-open" => "ctrl.showMenu"}
+        %button.item{"ng-click" => "ctrl.showMenu = !ctrl.showMenu; ctrl.showExtensions = false; ctrl.showEditorMenu = false;", "ng-class" => "{'selected' : ctrl.showMenu}", "click-outside" => "ctrl.showMenu = false;", "is-open" => "ctrl.showMenu"}
           .label Menu
           .menu-panel.dropdown-menu{"ng-if" => "ctrl.showMenu"}
             .section
@@ -42,11 +42,11 @@
               %menu-row{"title" => "'Monospace Font'", "circle" => "ctrl.monospaceFont ? 'success' : 'default'", "ng-click" => "ctrl.selectedMenuItem($event, true); ctrl.toggleKey('monospaceFont')"}
               %menu-row{"title" => "'Spellcheck'", "circle" => "ctrl.spellcheck ? 'success' : 'default'", "ng-click" => "ctrl.selectedMenuItem($event, true); ctrl.toggleKey('spellcheck')"}
 
-        .item{"ng-click" => "ctrl.onEditorMenuClick()", "ng-class" => "{'selected' : ctrl.showEditorMenu}", "click-outside" => "ctrl.showEditorMenu = false;", "is-open" => "ctrl.showEditorMenu"}
+        %button.item{"ng-click" => "ctrl.onEditorMenuClick()", "ng-class" => "{'selected' : ctrl.showEditorMenu}", "click-outside" => "ctrl.showEditorMenu = false;", "is-open" => "ctrl.showEditorMenu"}
           .label Editor
           %editor-menu{"ng-if" => "ctrl.showEditorMenu", "callback" => "ctrl.editorMenuOnSelect", "selected-editor" => "ctrl.selectedEditor", "current-item" => "ctrl.note"}
 
-        .item{"ng-click" => "ctrl.showExtensions = !ctrl.showExtensions; ctrl.showMenu = false; ctrl.showEditorMenu = false;", "ng-class" => "{'selected' : ctrl.showExtensions}", "click-outside" => "ctrl.showExtensions = false;", "is-open" => "ctrl.showExtensions"}
+        %button.item{"ng-click" => "ctrl.showExtensions = !ctrl.showExtensions; ctrl.showMenu = false; ctrl.showEditorMenu = false;", "ng-class" => "{'selected' : ctrl.showExtensions}", "click-outside" => "ctrl.showExtensions = false;", "is-open" => "ctrl.showExtensions"}
           .label Actions
           %actions-menu{"ng-if" => "ctrl.showExtensions", "item" => "ctrl.note"}
 

--- a/app/assets/templates/footer.html.haml
+++ b/app/assets/templates/footer.html.haml
@@ -1,7 +1,7 @@
 .sn-component
   #footer-bar.app-bar.no-edges
     .left
-      .item{"ng-click" => "ctrl.accountMenuPressed()", "click-outside" => "ctrl.showAccountMenu = false;", "is-open" => "ctrl.showAccountMenu"}
+      %button.item{"ng-click" => "ctrl.accountMenuPressed()", "click-outside" => "ctrl.showAccountMenu = false;", "is-open" => "ctrl.showAccountMenu"}
         .column
           .circle.small{"ng-class" => "ctrl.error ? 'danger' : (ctrl.getUser() ? 'info' : 'default')"}
         .column
@@ -22,7 +22,7 @@
 
     .right
 
-      .item{"ng-if" => "ctrl.newUpdateAvailable", "ng-click" => "ctrl.clickedNewUpdateAnnouncement()"}
+      %button.item{"ng-if" => "ctrl.newUpdateAvailable", "ng-click" => "ctrl.clickedNewUpdateAnnouncement()", "role" => "alert"}
         %span.info.label New update downloaded. Installs on app restart.
 
       .item.no-pointer{"ng-if" => "ctrl.lastSyncDate && !ctrl.isRefreshing"}
@@ -33,9 +33,9 @@
 
       .item{"ng-if" => "ctrl.offline"}
         .label Offline
-      .item{"ng-if" => "!ctrl.offline", "ng-click" => "ctrl.refreshData()"}
+      %button.item{"ng-if" => "!ctrl.offline", "ng-click" => "ctrl.refreshData()"}
         .label Refresh
 
-      .item#lock-item{"ng-if" => "ctrl.hasPasscode()"}
+      %button.item#lock-item{"ng-if" => "ctrl.hasPasscode()", "ng-click" => "ctrl.lockApp()", "aria-label" => "Lock"}
         .label
-          %i.icon.ion-locked#footer-lock-icon{"ng-if" => "ctrl.hasPasscode()", "ng-click" => "ctrl.lockApp()"}
+          %i.icon.ion-locked#footer-lock-icon

--- a/app/assets/templates/notes.html.haml
+++ b/app/assets/templates/notes.html.haml
@@ -4,14 +4,14 @@
       .padded
         .section-title-bar-header
           .title {{ctrl.panelTitle()}}
-          .add-button#notes-add-button{"ng-click" => "ctrl.createNewNote()"} +
+          %button.add-button#notes-add-button{"ng-click" => "ctrl.createNewNote()", "aria-label" => "Create note"} +
         .filter-section
           %input.filter-bar#search-bar.mousetrap{"select-on-click" => "true", "ng-model" => "ctrl.noteFilter.text", "placeholder" => "Search", "ng-change" => "ctrl.filterTextChanged()", "lowercase" => "true"}
             #search-clear-button{"ng-if" => "ctrl.noteFilter.text", "ng-click" => "ctrl.noteFilter.text = ''; ctrl.filterTextChanged()"} ✕
       .sn-component#notes-menu-bar
         .app-bar.no-edges
           .left
-            .item{"ng-click" => "ctrl.showMenu = !ctrl.showMenu", "ng-class" => "{'selected' : ctrl.showMenu}"}
+            %button.item{"ng-click" => "ctrl.showMenu = !ctrl.showMenu", "ng-class" => "{'selected' : ctrl.showMenu}"}
               .column
                 .label
                   Options

--- a/app/assets/templates/tags.html.haml
+++ b/app/assets/templates/tags.html.haml
@@ -7,7 +7,7 @@
     #tags-title-bar.section-title-bar
       .section-title-bar-header
         .title Tags
-        .add-button#tag-add-button{"ng-click" => "ctrl.clickedAddNewTag()"} +
+        %button.add-button#tag-add-button{"ng-click" => "ctrl.clickedAddNewTag()", "aria-label" => "Create tag"} +
 
     .scrollable
       .infinite-scroll
@@ -26,9 +26,9 @@
           .red.small.bold{"ng-if" => "tag.errorDecrypting"} Error decrypting
 
           .menu{"ng-if" => "ctrl.selectedTag == tag"}
-            %a.item{"ng-click" => "ctrl.selectedRenameTag($event, tag)", "ng-if" => "!ctrl.editingTag"} Rename
-            %a.item{"ng-click" => "ctrl.saveTag($event, tag)", "ng-if" => "ctrl.editingTag"} Save
-            %a.item{"ng-click" => "ctrl.selectedDeleteTag(tag)"} Delete
+            %a.item{"ng-click" => "ctrl.selectedRenameTag($event, tag)", "ng-if" => "!ctrl.editingTag", "href" => "#"} Rename
+            %a.item{"ng-click" => "ctrl.saveTag($event, tag)", "ng-if" => "ctrl.editingTag", "href" => "#"} Save
+            %a.item{"ng-click" => "ctrl.selectedDeleteTag(tag)", "href" => "#"} Delete
         .tag.faded{"ng-if" => "ctrl.archiveTag", "ng-click" => "ctrl.selectTag(ctrl.archiveTag)", "ng-class" => "{'selected' : ctrl.selectedTag == ctrl.archiveTag}"}
           .info
             %input.title{"ng-disabled" => "true", "ng-model" => "ctrl.archiveTag.title"}


### PR DESCRIPTION
Divs are not focusable by default, and need a considerable amount of JavaScript to make they behave similar to the native button element. This switches buttons implemented as divs to the native button element (styles are updated accordingly to maintain the same visual style). Link tags without href are also not focusable - for most of these cases the button element should be used, but that would involve a more significant refactoring, so I have opted to adding a dummy href.

While enabling keyboard navigation, this also addresses the fact that screen reader users had no idea that these buttons existed.