### PR TITLE
Highlight Search Results #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ Questions? Find answers on our [Help page](https://standardnotes.org/help).
 
 This repo contains the core code used in the web app, as well as the Electron-based [desktop application](https://github.com/standardnotes/desktop).
 
+**Note:** Ruby `2.3.1` is currently required for local development. [RVM](https://rvm.io/rvm/install) is a good solution if you need to install and use that version of Ruby.
+
 **Instructions:**
 
 1. Clone the repo
 1. `bundle install`
 1. `npm install`
 1. `bundle exec rake bower:install`
-1. `grunt`
+1. `npm run grunt`
 5. `rails s`
 
 Open your browser to http://localhost:3000.

--- a/app/assets/stylesheets/app/_editor.scss
+++ b/app/assets/stylesheets/app/_editor.scss
@@ -72,8 +72,6 @@ $heading-height: 75px;
 
     #note-tags-component-container {
       height: 50px;
-      overflow: auto; // Required for expired sub to not overflow
-
       iframe {
         height: 50px;
         width: 100%;
@@ -100,12 +98,28 @@ $heading-height: 75px;
 
   position: relative;
 
+  #note-text-editor {
+    z-index: 10;
+    height: 100%;
+    position: absolute;
+    background-color: transparent;
+  }
+
+  #note-text-editor-underlay {
+    z-index: 1;
+    height: 100%;
+    color: transparent;
+    .highlight {
+      background-color: yellow;
+    }
+  }
+
   #editor-iframe {
     flex: 1;
     width: 100%;
   }
 
-  .editable {
+  .editable, .uneditable {
     font-family: monospace;
     overflow-y: scroll;
     width: 100%;

--- a/app/assets/stylesheets/app/_notes.scss
+++ b/app/assets/stylesheets/app/_notes.scss
@@ -135,9 +135,10 @@
       display: -webkit-box;
       -webkit-box-orient: vertical;
       -webkit-line-clamp: 1; /* number of lines to show */
-      $line-height: 18px;
-      line-height: $line-height;        /* fallback */
-      max-height: calc(#{$line-height} * 1);       /* fallback */
+
+      .searchTermHighlight {
+        background-color: yellow;
+      }
     }
 
     &.selected {
@@ -147,6 +148,10 @@
       .pinned {
         color: white;
       }
+
+      .searchTermHighlight {
+        color: black;
+      }      
     }
 
   }

--- a/app/assets/templates/editor.html.haml
+++ b/app/assets/templates/editor.html.haml
@@ -60,6 +60,8 @@
      "ng-change" => "ctrl.contentChanged()", "ng-trim" => "false", "ng-click" => "ctrl.clickedTextArea()",
      "ng-focus" => "ctrl.onContentFocus()", "dir" => "auto", "ng-attr-spellcheck" => "{{ctrl.spellcheck}}"}
       {{ctrl.onSystemEditorLoad()}}
+    %div.uneditable#note-text-editor-underlay{"ng-if" => "ctrl.isWebApp && !ctrl.selectedEditor && !!ctrl.searchTerm",
+      "ng-bind-html" => "ctrl.note.text | highlightWeb:ctrl.searchTerm:!ctrl.selectedEditor"}
 
     %panel-resizer{"panel-id" => "'editor-content'", "on-resize-finish" => "ctrl.onPanelResizeFinish","control" => "ctrl.resizeControl", "min-width" => 300, "hoverable" => "true", "property" => "'right'"}
 

--- a/app/assets/templates/notes.html.haml
+++ b/app/assets/templates/notes.html.haml
@@ -60,7 +60,8 @@
 
           .name{"ng-if" => "note.title"}
             {{note.title}}
-          .note-preview{"ng-if" => "!ctrl.hideNotePreview"}
+          .note-preview{"ng-if" => "!ctrl.hideNotePreview && ctrl.isWebApp", "ng-bind-html" => "ctrl.highlightWebPreview(note.text)"}
+          .note-preview{"ng-if" => "!ctrl.hideNotePreview && !ctrl.isWebApp"}
             {{note.text}}
           .date.faded{"ng-if" => "!ctrl.hideDate"}
             %span{"ng-if" => "ctrl.sortBy == 'updated_at'"} Modified {{note.updatedAtString() || 'Now'}}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "url": "https://github.com/standardnotes/web"
   },
   "scripts": {
-    "test": "karma start karma.conf.js --single-run"
+    "test": "karma start karma.conf.js --single-run",
+    "grunt": "grunt"
   },
   "devDependencies": {
     "angular": "^1.6.1",


### PR DESCRIPTION
Adds search term highlighting in the notes preview pane, and plain text editor (issue #171). Highlighting is disabled on extended editors, but still works in the notes preview pane.

A few optional updates to README.md and package.json (related to `grunt` and `rvm`).