### PR TITLE
Update Dockerfile for optional production use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,22 @@ WORKDIR /app/
 
 COPY . /app/
 
+###
+# FOR PRODUCTION USE:
+#
+# If you need the app to continue listening on HTTP instead of HTTPS
+# (like terminating SSL on upstream server, i.e. Nginx proxy_pass to HTTP),
+# you will need to set 'config.force_ssl = false' in 'config/environments/production.rb'.
+#
+# Uncomment SECRET_KEY_BASE, RAILS_ENV, and [optionally] RAILS_SERVE_STATIC_FILES for production:
+# ENV SECRET_KEY_BASE=[VALUE OF `bundle exec rake secret`]
+#
+# ENV RAILS_ENV=production
+#
+# ENV RAILS_SERVE_STATIC_FILES=true
+# Leave RAILS_SERVE_STATIC_FILES commented if Nginx/Apache will serve static files instead of rails.
+###
+
 RUN bundle install
 
 RUN npm install
@@ -27,6 +43,9 @@ RUN npm install -g bower grunt
 RUN bundle exec rake bower:install
 
 RUN npm run build
+
+# Uncomment the line below for production:
+# RUN bundle exec rake assets:precompile
 
 EXPOSE 3000
 


### PR DESCRIPTION
Added commented-out portions of Dockerfile that can be uncommented for use in production. Additional instruction was supplied in Dockerfile comments to change parameter in config/environments/production.rb for standard Docker best practices production configuration.