### PR TITLE
Added component activation/register observers

### DIFF
--- a/app/assets/javascripts/app/services/componentManager.js
+++ b/app/assets/javascripts/app/services/componentManager.js
@@ -808,6 +808,8 @@ class ComponentManager {
       }
     });
     this.postActiveThemeToComponent(component);
+
+    this.desktopManager.notifyComponentActivation(component);
   }
 
   /* Performs func in timeout, but syncronously, if used `await waitTimeout` */

--- a/app/assets/javascripts/app/services/desktopManager.js
+++ b/app/assets/javascripts/app/services/desktopManager.js
@@ -10,7 +10,7 @@ class DesktopManager {
     this.$rootScope = $rootScope;
     this.timeout = $timeout;
     this.updateObservers = [];
-    this.activationObservers = [];
+    this.componentActivationObservers = [];
 
     this.isDesktop = isDesktopApplication();
 
@@ -110,21 +110,23 @@ class DesktopManager {
     });
   }
 
-  desktop_registerActivationObserver(callback) {
+  desktop_registerComponentActivationObserver(callback) {
     var observer = {id: Math.random, callback: callback};
-    this.activationObservers.push(observer);
+    this.componentActivationObservers.push(observer);
     return observer;
   }
 
-  desktop_deregisterActivationObserver(observer) {
-    _.pull(this.activationObservers, observer);
+  desktop_deregisterComponentActivationObserver(observer) {
+    _.pull(this.componentActivationObservers, observer);
   }
 
   /* Notify observers that a component has been registered/activated */
-  notifyComponentActivation(component) {
+  async notifyComponentActivation(component) {
+    var serializedComponent = await this.convertComponentForTransmission(component);
+
     this.timeout(() => {
-      for(var observer of this.activationObservers) {
-        observer.callback(component);
+      for(var observer of this.componentActivationObservers) {
+        observer.callback(serializedComponent);
       }
     });
   }

--- a/app/assets/javascripts/app/services/desktopManager.js
+++ b/app/assets/javascripts/app/services/desktopManager.js
@@ -10,6 +10,7 @@ class DesktopManager {
     this.$rootScope = $rootScope;
     this.timeout = $timeout;
     this.updateObservers = [];
+    this.activationObservers = [];
 
     this.isDesktop = isDesktopApplication();
 
@@ -106,7 +107,26 @@ class DesktopManager {
       for(var observer of this.updateObservers) {
         observer.callback(component);
       }
-    })
+    });
+  }
+
+  desktop_registerActivationObserver(callback) {
+    var observer = {id: Math.random, callback: callback};
+    this.activationObservers.push(observer);
+    return observer;
+  }
+
+  desktop_deregisterActivationObserver(observer) {
+    _.pull(this.activationObservers, observer);
+  }
+
+  /* Notify observers that a component has been registered/activated */
+  notifyComponentActivation(component) {
+    this.timeout(() => {
+      for(var observer of this.activationObservers) {
+        observer.callback(component);
+      }
+    });
   }
 
   /* Used to resolve "sn://" */


### PR DESCRIPTION
This allows the Desktop app to be notified when a component is registered and the iframe is ready.

Example usage: Observe a new component is registered to bind an eventListener on all new components. 