### PR TITLE
Reload any iframe components that had an issue while loading

### DIFF
--- a/app/assets/javascripts/app/directives/views/componentView.js
+++ b/app/assets/javascripts/app/directives/views/componentView.js
@@ -55,6 +55,7 @@ class ComponentView {
             $scope.loadTimeout = $timeout(() => {
               if($scope.loading) {
                 $scope.issueLoading = true;
+                componentManager.registerComponentForReload($scope.component);
               }
             }, 3500);
             iframe.onload = function(event) {


### PR DESCRIPTION
uses visibilityChange to try and reload any components which were marked as needing to be reloaded

Regarding: https://github.com/standardnotes/bounties/issues/14