### PR TITLE
fix(desktop): search highlight on pagination

### DIFF
--- a/app/assets/javascripts/app/controllers/notes.js
+++ b/app/assets/javascripts/app/controllers/notes.js
@@ -34,6 +34,7 @@ angular.module('app')
   .controller('NotesCtrl', function (authManager, $timeout, $rootScope, modelManager, storageManager, desktopManager) {
 
     this.panelController = {};
+    this.searchEntered = false;
 
     $rootScope.$on("user-preferences-changed", () => {
       this.loadPreferences();
@@ -106,6 +107,10 @@ angular.module('app')
     this.DefaultNotesToDisplayValue = (document.documentElement.clientHeight / MinNoteHeight) || 20;
 
     this.paginate = function() {
+      if (this.searchEntered) {
+        desktopManager.searchText(this.noteFilter.text);
+      }
+
       this.notesToDisplay += this.DefaultNotesToDisplayValue
     }
 
@@ -262,6 +267,7 @@ angular.module('app')
     this.onFilterEnter = function() {
       // For Desktop, performing a search right away causes input to lose focus.
       // We wait until user explicity hits enter before highlighting desktop search results.
+      this.searchEntered = true;
       desktopManager.searchText(this.noteFilter.text);
     }
 
@@ -275,6 +281,10 @@ angular.module('app')
     }
 
     this.filterTextChanged = function() {
+      if (this.searchEntered) {
+        this.searchEntered = false;
+      }
+
       $timeout(function(){
         if(!this.selectedNote.visible) {
           this.selectFirstNote(false);

--- a/app/assets/javascripts/app/controllers/notes.js
+++ b/app/assets/javascripts/app/controllers/notes.js
@@ -34,7 +34,7 @@ angular.module('app')
   .controller('NotesCtrl', function (authManager, $timeout, $rootScope, modelManager, storageManager, desktopManager) {
 
     this.panelController = {};
-    this.searchEntered = false;
+    this.searchSubmitted = false;
 
     $rootScope.$on("user-preferences-changed", () => {
       this.loadPreferences();
@@ -107,7 +107,7 @@ angular.module('app')
     this.DefaultNotesToDisplayValue = (document.documentElement.clientHeight / MinNoteHeight) || 20;
 
     this.paginate = function() {
-      if (this.searchEntered) {
+      if (this.searchSubmitted) {
         desktopManager.searchText(this.noteFilter.text);
       }
 
@@ -267,7 +267,7 @@ angular.module('app')
     this.onFilterEnter = function() {
       // For Desktop, performing a search right away causes input to lose focus.
       // We wait until user explicity hits enter before highlighting desktop search results.
-      this.searchEntered = true;
+      this.searchSubmitted = true;
       desktopManager.searchText(this.noteFilter.text);
     }
 
@@ -281,8 +281,8 @@ angular.module('app')
     }
 
     this.filterTextChanged = function() {
-      if (this.searchEntered) {
-        this.searchEntered = false;
+      if (this.searchSubmitted) {
+        this.searchSubmitted = false;
       }
 
       $timeout(function(){

--- a/app/assets/javascripts/app/controllers/notes.js
+++ b/app/assets/javascripts/app/controllers/notes.js
@@ -107,11 +107,11 @@ angular.module('app')
     this.DefaultNotesToDisplayValue = (document.documentElement.clientHeight / MinNoteHeight) || 20;
 
     this.paginate = function() {
+      this.notesToDisplay += this.DefaultNotesToDisplayValue
+
       if (this.searchSubmitted) {
         desktopManager.searchText(this.noteFilter.text);
       }
-
-      this.notesToDisplay += this.DefaultNotesToDisplayValue
     }
 
     this.resetPagination = function() {


### PR DESCRIPTION
Referencing issue standardnotes/bounties#20

Just triggering it on pagination caused some issues because typing in the search box can trigger it as well so I added a flag to prevent that.