### PR TITLE
Cleanup after bower removing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/standardnotes/web"
   },
   "scripts": {
-    "build": "bundle install && npm install && bundle exec && grunt",
+    "build": "bundle install && npm install && grunt",
     "submodules": "git submodule update --init --force --remote",
     "test": "karma start karma.conf.js --single-run"
   },


### PR DESCRIPTION

![standardnotes](https://user-images.githubusercontent.com/2753817/52376501-2f453a00-2a5a-11e9-9c90-40d8f28c588c.png)

In commit https://github.com/standardnotes/web/commit/4f423301674cdae960d7e93de9d75728d6e35b07 it was removed only partialy making it fail on execution.