### PR TITLE
fix: clear desktop search highlight when tag is selected

### DIFF
--- a/app/assets/javascripts/app/controllers/notes.js
+++ b/app/assets/javascripts/app/controllers/notes.js
@@ -309,6 +309,7 @@ angular.module('app')
       }
 
       this.noteFilter.text = "";
+      desktopManager.searchText();
 
       this.setNotes(tag.notes);
 


### PR DESCRIPTION
Removes the search highlight in the desktop app when a tag is selected

Closes #271 