### PR TITLE
Added support for theme color on Firefox progress bar

### DIFF
--- a/app/assets/stylesheets/app/_notes.scss
+++ b/app/assets/stylesheets/app/_notes.scss
@@ -198,13 +198,15 @@
     progress {
       background-color: var(--sn-stylekit-contrast-background-color);
       color: var(--sn-stylekit-info-color);
+      border: none;
     }
 
     progress::-webkit-progress-bar {
       background-color: var(--sn-stylekit-contrast-background-color);
     }
 
-    progress::-webkit-progress-value {
+    progress::-webkit-progress-value,
+    progress::-moz-progress-bar {
       background-color: var(--sn-stylekit-info-color);
     }
 
@@ -226,7 +228,8 @@
         background-color: var(--sn-stylekit-secondary-foreground-color);
       }
 
-      progress::-webkit-progress-value {
+      progress::-webkit-progress-value,
+      progress::-moz-progress-bar {
         background-color: var(--sn-stylekit-secondary-background-color);
       }
     }


### PR DESCRIPTION
Before/After:

![progressbars](https://user-images.githubusercontent.com/5969300/62174546-006c9a00-b300-11e9-9d22-386dad9371e7.png)


Fixes: https://github.com/sn-extensions/simple-task-editor/issues/22