### PR TITLE
Dock Icon Titles/Names

### DIFF
--- a/app/assets/javascripts/app/controllers/footer.js
+++ b/app/assets/javascripts/app/controllers/footer.js
@@ -213,11 +213,13 @@ angular.module('app')
       this.reloadDockShortcuts = function() {
         let shortcuts = [];
         for(var theme of this.themesWithIcons) {
+          var name = theme.content.package_info.name;
           var icon = theme.content.package_info.dock_icon;
           if(!icon) {
             continue;
           }
           shortcuts.push({
+            name: name,
             component: theme,
             icon: icon
           })

--- a/app/assets/templates/footer.html.haml
+++ b/app/assets/templates/footer.html.haml
@@ -53,9 +53,9 @@
 
       .sk-app-bar-item.dock-shortcut{"ng-repeat" => "shortcut in ctrl.dockShortcuts"}
         .sk-app-bar-item-column{"ng-click" => "ctrl.selectShortcut(shortcut)", "ng-class" => "{'underline': shortcut.component.active}"}
-          .div{"ng-if" => "shortcut.icon.type == 'circle'"}
+          .div{"ng-if" => "shortcut.icon.type == 'circle'", "title" => "{{shortcut.name}}"}
             .sk-circle.small{"ng-style" => "{'background-color': shortcut.icon.background_color, 'border-color': shortcut.icon.border_color}"}
-          .div{"ng-if" => "shortcut.icon.type == 'svg'"}
+          .div{"ng-if" => "shortcut.icon.type == 'svg'", "title" => "{{shortcut.name}}"}
             .svg-item{"ng-attr-id" => "dock-svg-{{shortcut.component.uuid}}", "elem-ready" => "ctrl.initSvgForShortcut(shortcut)"}
 
       .sk-app-bar-item.border{"ng-if" => "ctrl.hasPasscode()"}


### PR DESCRIPTION
Adds a title attribute to the dock icons in the footer to make it easier to identify which icon is for which theme. Requested: https://github.com/standardnotes/forum/issues/687

Excuse the added in mouse cursor ( print screen doesn't capture mouse D: )
![example](https://user-images.githubusercontent.com/5969300/64800213-c66ff400-d54b-11e9-8099-7123c1ba4763.png)
