### PR TITLE
Wait for the note filter text to be cleared before reloading notes after a tag change

### DIFF
--- a/app/assets/javascripts/controllers/notes/notes.js
+++ b/app/assets/javascripts/controllers/notes/notes.js
@@ -193,7 +193,7 @@ class NotesCtrl extends PureCtrl {
 
     this.resetScrollPosition();
     this.setShowMenuFalse();
-    this.setNoteFilterText('');
+    await this.setNoteFilterText('');
     this.desktopManager.searchText();
     this.resetPagination();
 


### PR DESCRIPTION
Wait for the note filter text to be cleared before reloading notes after a tag change.
(Fixes #363)