### PR TITLE
Web App Manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,25 @@
+{
+  "app": {
+    "launch": {
+      "urls": [
+        "https://app.standardnotes.org/"
+      ],
+      "web_url": "https://app.standardnotes.org",
+      "container": "tab"
+    }
+  },
+  "offline_enabled": true,
+  "permissions": [],
+  "requirements": {
+    "3D": {
+      "features": []
+    }
+  },
+  "icons": {
+    "128": "favicon/android-chrome-192x192.png"
+  },
+  "name": "Standard Notes",
+  "description": "A Simple And Private Notes App",
+  "version": "1.0",
+  "manifest_version": 2
+}


### PR DESCRIPTION
Currently, there's no `manifest.json` file that includes metadata like `name`, `description`, `icons`, etc.

> A user mentioned that the app icon on Chrome OS doesn't seem to be displaying properly, instead it just shows a black box with the letter S on it.

Here's the Standard Notes app without the `manifest.json` file:

![image](https://user-images.githubusercontent.com/5891646/76186549-020d1300-61a9-11ea-94c8-b297a03a0be1.png)

---

And here's the App with said file:

![image](https://user-images.githubusercontent.com/5891646/76186817-f0783b00-61a9-11ea-8ee8-0bc75056adb9.png)