### PR TITLE
Lowercase emails

### DIFF
--- a/app/assets/javascripts/directives/views/accountMenu.js
+++ b/app/assets/javascripts/directives/views/accountMenu.js
@@ -209,7 +209,7 @@ class AccountMenuCtrl extends PureCtrl {
     });
     const response = await this.authManager.register(
       this.state.formData.url,
-      this.state.formData.email,
+      this.state.formData.email.trim().toLowerCase(),
       this.state.formData.user_password,
       this.state.formData.ephemeral
     );

--- a/app/assets/javascripts/directives/views/accountMenu.js
+++ b/app/assets/javascripts/directives/views/accountMenu.js
@@ -201,7 +201,7 @@ class AccountMenuCtrl extends PureCtrl {
         text: STRING_NON_MATCHING_PASSWORDS
       });
       return;
-    }    
+    }
     await this.setFormDataState({
       confirmPassword: false,
       status: STRING_GENERATING_REGISTER_KEYS,
@@ -333,7 +333,7 @@ class AccountMenuCtrl extends PureCtrl {
   }
 
   /**
-   * @template 
+   * @template
    */
   async importFileSelected(files) {
     const run = async () => {


### PR DESCRIPTION
When registering, sends a trimmed + lowercase email.

I believe the syncing server's error message should be updated (instead of doing custom logic on the client) to provide a hint when the user fails to log in with an email containing spaces or uppercase letters. If you're of the same mind @mobitar then I'll log an issue on the repo as well