### PR TITLE
Fix component actions still running after destruction

### DIFF
--- a/app/assets/javascripts/directives/views/componentView.js
+++ b/app/assets/javascripts/directives/views/componentView.js
@@ -24,6 +24,7 @@ class ComponentViewCtrl {
     this.desktopManager = desktopManager;
     this.componentManager = componentManager;
     this.componentValid = true;
+    this.destroyed = false;
 
     $scope.$watch('ctrl.component', (component, prevComponent) => {
       this.componentValueDidSet(component, prevComponent);
@@ -32,6 +33,7 @@ class ComponentViewCtrl {
       this.reloadStatus(false);
     });
     $scope.$on('$destroy', () => {
+      this.destroyed = true;
       this.destroy();
     });
   }
@@ -92,6 +94,7 @@ class ComponentViewCtrl {
   async reloadComponent() {
     this.componentValid = false;
     await this.componentManager.reloadComponent(this.component);
+    if (this.destroyed) return;
     this.reloadStatus();
   }
 


### PR DESCRIPTION
Fixes [desktop#498](https://github.com/standardnotes/desktop/issues/498)
Basically, `reloadComponent()` being async, it can sometime still be running after `componentView` has been destroyed which can cause some weird (and hard to trace down) problems, our app freeze on desktop being one of them.
I chose to fix this by adding and checking against a boolean which is bad for maintenance but is the least disruptive thing to do code-wise. @mobitar you have a better visibility on how `snjs`'s refactor would/will impact this file than me so if you think we can go further with some kind of cancelation mechanism (which standard JS promises don't have) let me know 👍