### PR TITLE
First cut at removing distracting all changes saved status

### DIFF
--- a/app/assets/javascripts/controllers/editor.js
+++ b/app/assets/javascripts/controllers/editor.js
@@ -442,9 +442,9 @@ class EditorCtrl extends PureCtrl {
       saveError: false,
       syncTakingTooLong: false
     });
-    let status = "All changes saved";
+    let status = "";
     if (this.authManager.offline()) {
-      status += " (offline)";
+      status += "(offline)";
     }
     this.setStatus(
       { message: status }

--- a/app/assets/javascripts/controllers/editor.js
+++ b/app/assets/javascripts/controllers/editor.js
@@ -432,7 +432,7 @@ class EditorCtrl extends PureCtrl {
 
   showSavingStatus() {
     this.setStatus(
-      { message: "Saving..." },
+      { message: "" },
       false
     );
   }


### PR DESCRIPTION
Increases the simplicity of the editor by removing the `All changes saved` and `Saving...` state flickering animations.

Closes https://github.com/standardnotes/web/issues/410