### PR TITLE
refactor: actions menu

### DIFF
--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -26,7 +26,6 @@ type UpdateActionParams = {
 
 type UpdateExtensionParams = {
   hidden?: boolean
-  loading?: boolean
 }
 
 class ActionsMenuCtrl extends PureViewCtrl implements ActionsMenuScope {

--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -56,15 +56,13 @@ class ActionsMenuCtrl extends PureViewCtrl implements ActionsMenuScope {
     const actionExtensions = this.application.actionsManager!.getExtensions().sort((a, b) => {
       return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
     });
-    let extensionsForItem = [];
-    for (const extension of actionExtensions) {
-      const extensionInContext = await this.application.actionsManager!.loadExtensionInContextOfItem(
+    const extensionsForItem = await Promise.all(actionExtensions.map((extension) => {
+      return this.application.actionsManager!.loadExtensionInContextOfItem(
         extension,
         this.props.item
       );
-      extensionsForItem.push(extensionInContext);
-    }
-    if (actionExtensions.length == 0) {
+    }));
+    if (extensionsForItem.length == 0) {
       this.loadingExtensions = false;
     }
     await this.setState({

--- a/app/assets/templates/directives/actions-menu.pug
+++ b/app/assets/templates/directives/actions-menu.pug
@@ -7,19 +7,24 @@
       target='blank'
       )
       menu-row(label="'Download Actions'")
-    div(ng-repeat='extension in self.state.extensions track by extension.uuid')
+    div(ng-if='self.loadingExtensions')
+      .sk-menu-panel-header
+        .sk-menu-panel-column
+          .sk-menu-panel-header-title Loading...
+          .sk-spinner.small.loading
+    div(ng-repeat='extension in self.state.extensions track by extension.uuid; self.loadingExtensions = false')
       .sk-menu-panel-header(
-        ng-click='extension.hide = !extension.hide; $event.stopPropagation();'
+        ng-click='self.updateExtension(extension, { hidden: !extension.hidden }); $event.stopPropagation();'
         )
         .sk-menu-panel-column
           .sk-menu-panel-header-title {{extension.name}}
-          .sk-spinner.small.loading(ng-if='self.loadingState[extension.uuid]')
-          div(ng-if='extension.hide') …
+          div(ng-if='extension.hidden') …
       menu-row(
-        action='self.executeAction(action, extension);', 
+        action='self.executeAction(action, extension)', 
         label='action.label', 
-        ng-if='!extension.hide', 
-        ng-repeat='action in extension.actionsWithContextForItem(self.props.item)', 
+        ng-if='!extension.hidden', 
+        ng-repeat='action in extension.actionsWithContextForItem(self.props.item) track by $index', 
+        disabled='action.running'
         spinner-class="action.running ? 'info' : null", 
         sub-rows='action.subrows', 
         subtitle='action.desc'


### PR DESCRIPTION
The following PR refactors the legacy behavior for pre-immutability and adds the possibility to update properties for `actions` and `extensions`.

Required: https://github.com/standardnotes/snjs/pull/18