### PR TITLE
fix: update CSP to allow action bar to download notes

### DIFF
--- a/app/assets/templates/directives/component-view.pug
+++ b/app/assets/templates/directives/component-view.pug
@@ -89,7 +89,7 @@ iframe(
   ng-attr-id='component-iframe-{{ctrl.component.uuid}}', 
   ng-if='ctrl.component && ctrl.componentValid', 
   ng-src='{{ctrl.getUrl() | trusted}}', 
-  sandbox='allow-scripts allow-top-navigation-by-user-activation allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-modals allow-forms'
+  sandbox='allow-scripts allow-top-navigation-by-user-activation allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-modals allow-forms allow-downloads'
   )
   | Loading
 .loading-overlay(ng-if='ctrl.loading')

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,7 +43,7 @@ module StandardNotes
          base_uri: %w('self'),
          block_all_mixed_content: false, # see http://www.w3.org/TR/mixed-content/
          child_src: ["*", "blob:"],
-         frame_src: ["*", "blob:"],
+         frame_src: ["*", "blob:", "data:"],
          connect_src: ["*"],
          font_src: %w(* 'self'),
          form_action: %w('self'),


### PR DESCRIPTION
This is regarding an issue pointed out by @not-a-robot-yet and fixes standardnotes/action-bar#8.

Since the Action Bar extension works in the desktop app, I decided to look at what was different in the web app. This was the error I got when using the Action Bar:
```
Content Security Policy: The page’s settings blocked the loading of a resource at data:text/plain;charset=utf-8,%3Cp%20dir… (“frame-src”).
```
I think it can be fixed by allowing `'data:'` in the `frame-src` CSP because this is how the Action Bar saves the note: 
```javascript
pom.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
``` 

I'm not too familiar with the web app, but perhaps you guys could weigh in on the security implications.