### PR TITLE
fix: initialize userPreferences in preferencesManager

### DIFF
--- a/app/assets/javascripts/services/preferencesManager.ts
+++ b/app/assets/javascripts/services/preferencesManager.ts
@@ -25,6 +25,9 @@ export class PreferencesManager extends ApplicationService {
   }
 
   streamPreferences() {
+    if (!this.userPreferences) {
+      this.loadSingleton();
+    }
     this.application!.streamItems(
       ContentType.UserPrefs,
       () => {

--- a/app/assets/javascripts/services/preferencesManager.ts
+++ b/app/assets/javascripts/services/preferencesManager.ts
@@ -17,6 +17,7 @@ export class PreferencesManager extends ApplicationService {
   /** @override */
   async onAppLaunch() {
     super.onAppLaunch();
+    this.reloadSingleton();
     this.streamPreferences();
   }
 
@@ -25,18 +26,15 @@ export class PreferencesManager extends ApplicationService {
   }
 
   streamPreferences() {
-    if (!this.userPreferences) {
-      this.loadSingleton();
-    }
     this.application!.streamItems(
       ContentType.UserPrefs,
       () => {
-        this.loadSingleton();
+        this.reloadSingleton();
       }
     );
   }
 
-  private async loadSingleton() {
+  private async reloadSingleton() {
     if(this.loadingPrefs) {
       return;
     }


### PR DESCRIPTION
Newly created accounts do not have a `UserPrefs` item:

![image](https://user-images.githubusercontent.com/5891646/85501154-cc9f0080-b5b2-11ea-9f6b-cebf40bc737a.png)

The present PR aims to fix this issue by calling `this.loadSingleton();` if User preferences are `undefined`.