### PR TITLE
fix: load/unload tags component on change

### DIFF
--- a/app/assets/javascripts/views/editor/editor_view.ts
+++ b/app/assets/javascripts/views/editor/editor_view.ts
@@ -387,6 +387,7 @@ class EditorViewCtrl extends PureViewCtrl implements EditorViewScope {
         }
         /** Reload componentStack in case new ones were added or removed */
         await this.reloadComponentStack();
+        this.reloadNoteTagsComponent();
         /** Observe editor changes to see if the current note should update its editor */
         const editors = components.filter((component) => {
           return component.isEditor();
@@ -1107,6 +1108,18 @@ class EditorViewCtrl extends PureViewCtrl implements EditorViewScope {
         }
       }
     });
+  }
+
+  reloadNoteTagsComponent() {
+    const components = this.application.componentManager!
+      .componentsForArea(ComponentArea.NoteTags);
+    for (const component of components) {
+      if (component.active) {
+        this.componentGroup.activateComponent(component);
+      } else {
+        this.componentGroup.deactivateComponent(component);
+      }
+    }
   }
 
   async reloadComponentStack() {


### PR DESCRIPTION
Currently the tags component doesn't get loaded or unloaded when we active/deactivate it from the extensions manager. This PR addresses that (though I would appreciate a review given my currently incomplete understanding of the editor view)