### PR TITLE
fix: switching to plain editor

### DIFF
--- a/app/assets/javascripts/views/editor/editor_view.ts
+++ b/app/assets/javascripts/views/editor/editor_view.ts
@@ -443,7 +443,7 @@ class EditorViewCtrl extends PureViewCtrl<{}, EditorState> {
           noteMutator.prefersPlainEditor = true;
         })
       }
-      if (this.activeEditorComponent?.isExplicitlyEnabledForItem(this.note.uuid)) {
+      if (activeEditorComponent) {
         await this.disassociateComponentWithCurrentNote(this.activeEditorComponent);
       }
       await this.reloadComponentEditorState();


### PR DESCRIPTION
Make it possible to switch to the plain editor if another editor is default