### PR TITLE
fix: ionicons not found on webpack dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "start": "webpack-dev-server --progress",
     "bundle": "webpack --mode production",
-    "build": "bundle install && npm ci && bundle exec rails assets:precompile && npm run bundle",
+    "precompile:assets": "bundle exec rails assets:precompile",
+    "postinstall": "npm run precompile:assets",
+    "build": "bundle install && npm ci && npm run precompile:assets && npm run bundle",
     "submodules": "git submodule update --init --force --remote",
     "test": "karma start karma.conf.js --single-run",
     "lint": "eslint --fix app/assets/javascripts/**/*.js"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,8 @@ const path = require('path');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
+const port = 3000;
+
 module.exports = {
   entry: './app/assets/javascripts/index.js',
   output: {
@@ -10,11 +12,15 @@ module.exports = {
   devServer: {
     proxy: {
       '/extensions': {
-        target: 'http://localhost:3000',
+        target: `http://localhost:${port}`,
         pathRewrite: { '^/extensions': '/public/extensions' }
+      },
+      '/assets': {
+        target: `http://localhost:${port}`,
+        pathRewrite: { '^/assets': '/public/assets' }
       }
     },
-    port: 3000
+    port
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
- [x] fonts are loading in dev server
- [x] precompile assets after installing dependencies
- [x] assets are served via `/assets` path