### PR TITLE
fix: proper names for actions and history menus

### DIFF
--- a/app/assets/javascripts/views/editor/editor-view.pug
+++ b/app/assets/javascripts/views/editor/editor-view.pug
@@ -171,26 +171,27 @@
             application='self.application'
             )
         .sk-app-bar-item(
-          click-outside=`self.setMenuState('showExtensions', false)`,
-          is-open='self.state.showExtensions',
-          ng-class="{'selected' : self.state.showExtensions}",
-          ng-click="self.toggleMenu('showExtensions')"
+          click-outside=`self.setMenuState('showActionsMenu', false)`,
+          is-open='self.state.showActionsMenu',
+          ng-class="{'selected' : self.state.showActionsMenu}",
+          ng-click="self.toggleMenu('showActionsMenu')"
           )
           .sk-label Actions
           actions-menu(
             item='self.note',
-            ng-if='self.state.showExtensions',
+            ng-if='self.state.showActionsMenu',
             application='self.application'
             )
         .sk-app-bar-item(
-          click-outside=`self.setMenuState('showHistory', false)`,
-          is-open='self.state.showHistory',
-          ng-click="self.toggleMenu('showHistory')"
+          click-outside=`self.setMenuState('showHistoryMenu', false)`,
+          is-open='self.state.showHistoryMenu',
+          ng-class="{'selected' : self.state.showHistoryMenu}",
+          ng-click="self.toggleMenu('showHistoryMenu')"
           )
           .sk-label History
           history-menu(
             item='self.note',
-            ng-if='self.state.showHistory',
+            ng-if='self.state.showHistoryMenu',
             application='self.application'
             )
   #editor-content.editor-content(ng-if='!self.note.errorDecrypting')

--- a/app/assets/javascripts/views/editor/editor_view.ts
+++ b/app/assets/javascripts/views/editor/editor_view.ts
@@ -68,10 +68,10 @@ type EditorState = {
   monospaceFont?: boolean
   isDesktop?: boolean
   syncTakingTooLong: boolean
-  showExtensions: boolean
+  showActionsMenu: boolean
   showOptionsMenu: boolean
   showEditorMenu: boolean
-  showSessionHistory: boolean
+  showHistoryMenu: boolean
   altKeyDown: boolean
   spellcheck: boolean
   /**
@@ -217,10 +217,10 @@ class EditorViewCtrl extends PureViewCtrl<{}, EditorState> {
       isDesktop: isDesktopApplication(),
       spellcheck: true,
       syncTakingTooLong: false,
-      showExtensions: false,
+      showActionsMenu: false,
       showOptionsMenu: false,
       showEditorMenu: false,
-      showSessionHistory: false,
+      showHistoryMenu: false,
       altKeyDown: false,
       noteStatus: undefined,
       editorUnloading: false,
@@ -275,10 +275,10 @@ class EditorViewCtrl extends PureViewCtrl<{}, EditorState> {
   async handleEditorNoteChange() {
     this.cancelPendingSetStatus();
     await this.setState({
-      showExtensions: false,
+      showActionsMenu: false,
       showOptionsMenu: false,
       showEditorMenu: false,
-      showSessionHistory: false,
+      showHistoryMenu: false,
       altKeyDown: false,
       noteStatus: undefined
     });
@@ -383,8 +383,8 @@ class EditorViewCtrl extends PureViewCtrl<{}, EditorState> {
     const allMenus = [
       'showOptionsMenu',
       'showEditorMenu',
-      'showExtensions',
-      'showHistory',
+      'showActionsMenu',
+      'showHistoryMenu',
     ];
     const menuState: any = {};
     for (const candidate of allMenus) {


### PR DESCRIPTION
- [x] renames `showExtensions` to `showActionsMenu`
- [x] renames `showHistory` to `showHistoryMenu`
- [x] fix remaining `showSessionHistory` references to `showHistoryMenu`