### PR TITLE
docker - start the rails server as the main process

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ case "$1" in
     echo "Prestart Step 1/1 - Removing server lock"
     rm -f /app/tmp/pids/server.pid
     echo "Starting Server..."
-    bundle exec rails s -b 0.0.0.0
+    exec bundle exec rails s -b 0.0.0.0
     ;;
 
    * )

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -21,7 +21,7 @@ case "$1" in
     echo "Prestart Step 5/5 - Compiling assets"
     bundle exec rails assets:precompile
     echo "Starting Server..."
-    bundle exec rails s -b 0.0.0.0
+    exec bundle exec rails s -b 0.0.0.0
     ;;
 
    * )


### PR DESCRIPTION
If you start a process from inside a shell script, it runs as a child process. And it would not allow the child process (in this case, the rails server) to handle signals like SIGTERM or SIGINT properly. Using `exec` lets the child process take over as the parent process.

To test this, start a docker container containing the older entrypoint.sh

```
docker run -d --name sn standardnotes/web
docker stop sn
docker logs sn
```

In the logs, you will see that the rails server did not shut down properly.

Now build a new image containing the updated entrypoint.sh

```
docker build -t sn_new .
docker rm sn
docker run -d --name sn sn_new
docker stop sn
docker logs sn
```

This time in the logs, you should see the rails server gracefully shutting down.