### PR TITLE
fix: upon extension error, loading spinner should be removed

### DIFF
--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -68,7 +68,9 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
         extension,
         this.item
       );
-      await this.updateExtension(updatedExtension!);
+      if (updatedExtension) {
+        await this.updateExtension(updatedExtension!);
+      }
       await this.setLoadingExtension(extension.uuid, false);
     }));
   }

--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -32,7 +32,7 @@ type ExtensionState = {
 
 type ActionsMenuState = {
   extensions: SNActionsExtension[]
-  extensionState: Record<UuidString, ExtensionState>
+  extensionsState: Record<UuidString, ExtensionState>
 }
 
 class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements ActionsMenuScope {
@@ -59,9 +59,17 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
     const extensions = this.application.actionsManager!.getExtensions().sort((a, b) => {
       return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
     });
+    let extensionsState: Record<UuidString, ExtensionState> = {};
+    extensions.map((extension) => {
+      extensionsState[extension.uuid] = {
+        loading: false,
+        error: false,
+        hidden: false
+      };
+    });
     return {
       extensions,
-      extensionState: {}
+      extensionsState
     };
   }
 
@@ -186,42 +194,42 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
   }
 
   private async toggleExtensionVisibility(extensionUuid: UuidString) {
-    const { extensionState } = this.state;
-    extensionState[extensionUuid].hidden = !extensionState[extensionUuid].hidden ?? false;
+    const { extensionsState } = this.state;
+    extensionsState[extensionUuid].hidden = !extensionsState[extensionUuid].hidden;
     await this.setState({
-      extensionState
+      extensionsState
     });
   }
 
   private isExtensionVisible(extensionUuid: UuidString) {
-    const { extensionState } = this.state;
-    return extensionState[extensionUuid].hidden ?? false;
+    const { extensionsState } = this.state;
+    return extensionsState[extensionUuid].hidden;
   }
 
   private async setLoadingExtension(extensionUuid: UuidString, value = false) {
-    const { extensionState } = this.state;
-    extensionState[extensionUuid].loading = value;
+    const { extensionsState } = this.state;
+    extensionsState[extensionUuid].loading = value;
     await this.setState({
-      extensionState
+      extensionsState
     });
   }
 
   private isExtensionLoading(extensionUuid: UuidString) {
-    const { extensionState } = this.state;
-    return extensionState[extensionUuid].loading ?? false;
+    const { extensionsState } = this.state;
+    return extensionsState[extensionUuid].loading;
   }
 
   private async setErrorExtension(extensionUuid: UuidString, value = false) {
-    const { extensionState } = this.state;
-    extensionState[extensionUuid].error = value;
+    const { extensionsState } = this.state;
+    extensionsState[extensionUuid].error = value;
     await this.setState({
-      extensionState
+      extensionsState
     });
   }
 
   private extensionHasError(extensionUuid: UuidString) {
-    const { extensionState } = this.state;
-    return extensionState[extensionUuid].error ?? false;
+    const { extensionsState } = this.state;
+    return extensionsState[extensionUuid].error;
   }
 }
 

--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -25,9 +25,10 @@ type UpdateActionParams = {
 }
 
 type ActionsMenuState = {
-  extensions: SNActionsExtension[],
+  extensions: SNActionsExtension[]
   hiddenState: Record<UuidString, Boolean>
   loadingState: Record<UuidString, Boolean>
+  errorState: Record<UuidString, Boolean>
 }
 
 class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements ActionsMenuScope {
@@ -57,7 +58,8 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
     return {
       extensions,
       loadingState: {},
-      hiddenState: {}
+      hiddenState: {},
+      errorState: {}
     };
   }
 
@@ -70,6 +72,8 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
       );
       if (updatedExtension) {
         await this.updateExtension(updatedExtension!);
+      } else {
+        await this.setErrorExtension(extension.uuid, true);
       }
       await this.setLoadingExtension(extension.uuid, false);
     }));
@@ -203,6 +207,19 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
   private isExtensionLoading(extensionUuid: UuidString) {
     const { loadingState } = this.state;
     return loadingState[extensionUuid] ?? false;
+  }
+
+  private async setErrorExtension(extensionUuid: UuidString, value = false) {
+    const { errorState } = this.state;
+    errorState[extensionUuid] = value;
+    await this.setState({
+      errorState
+    });
+  }
+
+  private extensionHasError(extensionUuid: UuidString) {
+    const { errorState } = this.state;
+    return errorState[extensionUuid] ?? false;
   }
 }
 

--- a/app/assets/javascripts/directives/views/actionsMenu.ts
+++ b/app/assets/javascripts/directives/views/actionsMenu.ts
@@ -24,11 +24,15 @@ type UpdateActionParams = {
   subrows?: ActionSubRow[]
 }
 
+type ExtensionState = {
+  hidden: boolean
+  loading: boolean
+  error: boolean
+}
+
 type ActionsMenuState = {
   extensions: SNActionsExtension[]
-  hiddenState: Record<UuidString, Boolean>
-  loadingState: Record<UuidString, Boolean>
-  errorState: Record<UuidString, Boolean>
+  extensionState: Record<UuidString, ExtensionState>
 }
 
 class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements ActionsMenuScope {
@@ -57,9 +61,7 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
     });
     return {
       extensions,
-      loadingState: {},
-      hiddenState: {},
-      errorState: {}
+      extensionState: {}
     };
   }
 
@@ -184,42 +186,42 @@ class ActionsMenuCtrl extends PureViewCtrl<{}, ActionsMenuState> implements Acti
   }
 
   private async toggleExtensionVisibility(extensionUuid: UuidString) {
-    const { hiddenState } = this.state;
-    hiddenState[extensionUuid] = !hiddenState[extensionUuid] ?? false;
+    const { extensionState } = this.state;
+    extensionState[extensionUuid].hidden = !extensionState[extensionUuid].hidden ?? false;
     await this.setState({
-      hiddenState
+      extensionState
     });
   }
 
   private isExtensionVisible(extensionUuid: UuidString) {
-    const { hiddenState } = this.state;
-    return hiddenState[extensionUuid] ?? false;
+    const { extensionState } = this.state;
+    return extensionState[extensionUuid].hidden ?? false;
   }
 
   private async setLoadingExtension(extensionUuid: UuidString, value = false) {
-    const { loadingState } = this.state;
-    loadingState[extensionUuid] = value;
+    const { extensionState } = this.state;
+    extensionState[extensionUuid].loading = value;
     await this.setState({
-      loadingState
+      extensionState
     });
   }
 
   private isExtensionLoading(extensionUuid: UuidString) {
-    const { loadingState } = this.state;
-    return loadingState[extensionUuid] ?? false;
+    const { extensionState } = this.state;
+    return extensionState[extensionUuid].loading ?? false;
   }
 
   private async setErrorExtension(extensionUuid: UuidString, value = false) {
-    const { errorState } = this.state;
-    errorState[extensionUuid] = value;
+    const { extensionState } = this.state;
+    extensionState[extensionUuid].error = value;
     await this.setState({
-      errorState
+      extensionState
     });
   }
 
   private extensionHasError(extensionUuid: UuidString) {
-    const { errorState } = this.state;
-    return errorState[extensionUuid] ?? false;
+    const { extensionState } = this.state;
+    return extensionState[extensionUuid].error ?? false;
   }
 }
 

--- a/app/assets/templates/directives/actions-menu.pug
+++ b/app/assets/templates/directives/actions-menu.pug
@@ -19,7 +19,7 @@
       menu-row(
         action='self.executeAction(action, extension)', 
         label='action.label', 
-        ng-if='!self.isExtensionVisible(extension.uuid) && !self.isExtensionLoading(extension.uuid)', 
+        ng-if='!self.isExtensionVisible(extension.uuid) && !self.isExtensionLoading(extension.uuid) && !self.extensionHasError(extension.uuid)', 
         ng-repeat='action in extension.actionsWithContextForItem(self.item) track by $index', 
         disabled='action.running'
         spinner-class="action.running ? 'info' : null", 
@@ -34,4 +34,10 @@
         faded='true', 
         label="'No Actions Available'", 
         ng-if='extension.actionsWithContextForItem(self.item).length == 0'
+        )
+      menu-row(
+        faded='true', 
+        label="'Error loading actions'", 
+        subtitle="'Please try again later.'"
+        ng-if='self.extensionHasError(extension.uuid)'
         )


### PR DESCRIPTION
- [x] loading spinner is removed even if an error occurs
- [x] a row with the text "Error loading actions" is shown in case the extension fails to be load