### PR TITLE
fix: prevent importing backup files with version > 003 

### DIFF
--- a/app/assets/javascripts/directives/views/accountMenu.js
+++ b/app/assets/javascripts/directives/views/accountMenu.js
@@ -20,6 +20,7 @@ import {
   STRING_GENERATING_REGISTER_KEYS,
   StringImportError
 } from '@/strings';
+import { STRING_IMPORT_FAILED_NEWER_BACKUP } from '../../strings';
 
 const ELEMENT_ID_IMPORT_PASSWORD_INPUT = 'import-password-request';
 
@@ -204,7 +205,7 @@ class AccountMenuCtrl extends PureCtrl {
         text: STRING_NON_MATCHING_PASSWORDS
       });
       return;
-    }    
+    }
     await this.setFormDataState({
       confirmPassword: false,
       status: STRING_GENERATING_REGISTER_KEYS,
@@ -336,7 +337,7 @@ class AccountMenuCtrl extends PureCtrl {
   }
 
   /**
-   * @template 
+   * @template
    */
   async importFileSelected(files) {
     const run = async () => {
@@ -377,17 +378,15 @@ class AccountMenuCtrl extends PureCtrl {
   }
 
   async performImport(data, password) {
-    if (data.keyParams) {
-      if (Number(data.keyParams.version) > 3) {
-        this.setState({
-          importData: null
-        });
-        this.alertManager.alert({
-          text: "This backup file was created using a later version of the application and cannot be imported."
-        });
-        return;
-      }
+    if (
+      data.keyParams ||
+      (data.auth_params && Number(data.auth_params.version) > protocolManager.version())
+    ) {
+      this.setState({ importData: null });
+      this.alertManager.alert({ text: STRING_IMPORT_FAILED_NEWER_BACKUP });
+      return;
     }
+
     await this.setState({
       importData: {
         ...this.state.importData,

--- a/app/assets/javascripts/directives/views/accountMenu.js
+++ b/app/assets/javascripts/directives/views/accountMenu.js
@@ -377,6 +377,17 @@ class AccountMenuCtrl extends PureCtrl {
   }
 
   async performImport(data, password) {
+    if (data.keyParams) {
+      if (Number(data.keyParams.version) > 3) {
+        this.setState({
+          importData: null
+        });
+        this.alertManager.alert({
+          text: "This backup file was created using a later version of the application and cannot be imported."
+        });
+        return;
+      }
+    }
     await this.setState({
       importData: {
         ...this.state.importData,

--- a/app/assets/javascripts/directives/views/accountMenu.js
+++ b/app/assets/javascripts/directives/views/accountMenu.js
@@ -346,6 +346,12 @@ class AccountMenuCtrl extends PureCtrl {
       if (!data) {
         return;
       }
+      const version = data?.auth_params?.version || data?.keyParams?.version;
+      if (!protocolManager.supportedVersions().includes(version)) {
+        this.setState({ importData: null });
+        this.alertManager.alert({ text: STRING_IMPORT_FAILED_NEWER_BACKUP });
+        return;
+      }
       if (data.auth_params) {
         await this.setState({
           importData: {
@@ -378,15 +384,6 @@ class AccountMenuCtrl extends PureCtrl {
   }
 
   async performImport(data, password) {
-    if (
-      data.keyParams ||
-      (data.auth_params && Number(data.auth_params.version) > protocolManager.version())
-    ) {
-      this.setState({ importData: null });
-      this.alertManager.alert({ text: STRING_IMPORT_FAILED_NEWER_BACKUP });
-      return;
-    }
-
     await this.setState({
       importData: {
         ...this.state.importData,

--- a/app/assets/javascripts/strings.js
+++ b/app/assets/javascripts/strings.js
@@ -49,3 +49,5 @@ export function StringImportError({errorCount}) {
 
 /** @password_change */
 export const STRING_FAILED_PASSWORD_CHANGE = "There was an error re-encrypting your items. Your password was changed, but not all your items were properly re-encrypted and synced. You should try syncing again. If all else fails, you should restore your notes from backup.";
+
+export const STRING_IMPORT_FAILED_NEWER_BACKUP = "This backup file was created using a newer version of the application and cannot be imported here. Please update your application and try again.";

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "start": "webpack-dev-server --progress",
     "bundle": "webpack --mode production",
     "precompile:assets": "bundle exec rails assets:precompile",
-    "postinstall": "npm run precompile:assets",
     "build": "bundle install && npm ci && npm run precompile:assets && npm run bundle",
     "submodules": "git submodule update --init --force --remote",
     "test": "karma start karma.conf.js --single-run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "standard-notes-web",
-  "version": "3.3.6",
+  "version": "3.3.10",
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This code is not future-proof but because `master` is so different from `develop` I'll have to develop the same thing again on `develop` anyway, where I'll actually check the account version (or do something else that doesn't have hardcoded version numbers)