### PR TITLE
fix missing whitespace in permissions-modal

### DIFF
--- a/app/assets/templates/directives/permissions-modal.pug
+++ b/app/assets/templates/directives/permissions-modal.pug
@@ -15,6 +15,7 @@
           .sk-panel-row
             p.sk-p
               | Extensions use an offline messaging system to communicate. Learn more at
+              | 
               a.sk-a.info(
                 href='https://standardnotes.org/permissions',
                 rel='noopener',


### PR DESCRIPTION
Before (note the missing space after "Learn more at":
<img width="341" alt="Screen Shot 2021-05-30 at 3 48 12 PM" src="https://user-images.githubusercontent.com/25125937/120104851-3cbceb80-c15f-11eb-99ce-5cc9bdcd9f23.png">

After:
<img width="346" alt="Screen Shot 2021-05-30 at 4 07 13 PM" src="https://user-images.githubusercontent.com/25125937/120105325-2152e000-c161-11eb-9524-7e00716ce5ec.png">


Adding an extra piped line is the recommended solution to this according to https://pugjs.org/language/plain-text.html#recommended-solutions (vs adding a leading or trailing space).