### PR TITLE
fix: don't wait until regaining focus to lock app

### DIFF
--- a/app/assets/javascripts/services/autolock_service.ts
+++ b/app/assets/javascripts/services/autolock_service.ts
@@ -2,7 +2,7 @@ import { ApplicationService } from '@standardnotes/snjs';
 import { isDesktopApplication } from '@/utils';
 
 const MILLISECONDS_PER_SECOND = 1000;
-const POLL_INTERVAL = 10;
+const POLL_INTERVAL = 50;
 const LOCK_INTERVAL_NONE = 0;
 const LOCK_INTERVAL_IMMEDIATE = 1;
 const LOCK_INTERVAL_ONE_MINUTE = 60 * MILLISECONDS_PER_SECOND;

--- a/app/assets/javascripts/services/autolock_service.ts
+++ b/app/assets/javascripts/services/autolock_service.ts
@@ -1,10 +1,8 @@
 import { ApplicationService } from '@standardnotes/snjs';
-import { WebApplication } from '@/ui_models/application';
 import { isDesktopApplication } from '@/utils';
-import { AppStateEvent } from '@/ui_models/app_state';
 
 const MILLISECONDS_PER_SECOND = 1000;
-const FOCUS_POLL_INTERVAL = 1 * MILLISECONDS_PER_SECOND;
+const POLL_INTERVAL = 10;
 const LOCK_INTERVAL_NONE = 0;
 const LOCK_INTERVAL_IMMEDIATE = 1;
 const LOCK_INTERVAL_ONE_MINUTE = 60 * MILLISECONDS_PER_SECOND;
@@ -15,37 +13,21 @@ const STORAGE_KEY_AUTOLOCK_INTERVAL = "AutoLockIntervalKey";
 
 export class AutolockService extends ApplicationService {
 
-  private unsubState?: () => void;
-  private pollFocusInterval: any
+  private pollInterval: any
   private lastFocusState?: 'hidden' | 'visible'
   private lockAfterDate?: Date
-  private lockTimeout?: any
 
   onAppLaunch() {
-    this.observeVisibility();
+    if (!isDesktopApplication()) {
+      this.beginPolling();
+    }
     return super.onAppLaunch();
   }
 
-  observeVisibility() {
-    this.unsubState = (this.application as WebApplication).getAppState().addObserver(
-      async (eventName) => {
-        if (eventName === AppStateEvent.WindowDidBlur) {
-          this.documentVisibilityChanged(false);
-        } else if (eventName === AppStateEvent.WindowDidFocus) {
-          this.documentVisibilityChanged(true);
-        }
-      }
-    );
-    if (!isDesktopApplication()) {
-      this.beginWebFocusPolling();
-    }
-  }
-
   deinit() {
-    this.unsubState?.();
     this.cancelAutoLockTimer();
-    if (this.pollFocusInterval) {
-      clearInterval(this.pollFocusInterval);
+    if (this.pollInterval) {
+      clearInterval(this.pollInterval);
     }
   }
 
@@ -85,11 +67,15 @@ export class AutolockService extends ApplicationService {
    *  Verify document is in focus every so often as visibilitychange event is
    *  not triggered on a typical window blur event but rather on tab changes.
    */
-  beginWebFocusPolling() {
-    this.pollFocusInterval = setInterval(() => {
-      if (document.hidden) {
-        /** Native event listeners will have fired */
-        return;
+  beginPolling() {
+    this.pollInterval = setInterval(async () => {
+      const locked = await this.application.isLocked();
+      if (
+        !locked &&
+        this.lockAfterDate &&
+        new Date() > this.lockAfterDate
+      ) {
+        this.lockApplication();
       }
       const hasFocus = document.hasFocus();
       if (hasFocus && this.lastFocusState === 'hidden') {
@@ -99,7 +85,7 @@ export class AutolockService extends ApplicationService {
       }
       /* Save this to compare against next time around */
       this.lastFocusState = hasFocus ? 'visible' : 'hidden';
-    }, FOCUS_POLL_INTERVAL);
+    }, POLL_INTERVAL);
   }
 
   getAutoLockIntervalOptions() {
@@ -129,14 +115,6 @@ export class AutolockService extends ApplicationService {
 
   async documentVisibilityChanged(visible: boolean) {
     if (visible) {
-      const locked = await this.application.isLocked();
-      if (
-        !locked &&
-        this.lockAfterDate &&
-        new Date() > this.lockAfterDate
-      ) {
-        this.lockApplication();
-      }
       this.cancelAutoLockTimer();
     } else {
       this.beginAutoLockTimer();
@@ -148,29 +126,15 @@ export class AutolockService extends ApplicationService {
     if (interval === LOCK_INTERVAL_NONE) {
       return;
     }
-    /**
-     * Use a timeout if possible, but if the computer is put to sleep, timeouts won't
-     * work. Need to set a date as backup. this.lockAfterDate does not need to be
-     * persisted,  as living in memory is sufficient. If memory is cleared, then the
-     * application will lock anyway.
-     */
     const addToNow = (seconds: number) => {
       const date = new Date();
       date.setSeconds(date.getSeconds() + seconds);
       return date;
     };
     this.lockAfterDate = addToNow(interval / MILLISECONDS_PER_SECOND);
-    clearTimeout(this.lockTimeout);
-    this.lockTimeout = setTimeout(() => {
-      this.cancelAutoLockTimer();
-      this.lockApplication();
-      this.lockAfterDate = undefined;
-    }, interval);
   }
 
   cancelAutoLockTimer() {
-    clearTimeout(this.lockTimeout);
     this.lockAfterDate = undefined;
-    this.lockTimeout = undefined;
   }
 }

--- a/app/assets/javascripts/ui_models/app_state/app_state.ts
+++ b/app/assets/javascripts/ui_models/app_state/app_state.ts
@@ -134,7 +134,7 @@ export class AppState {
       this.noAccountWarning.reset();
     }
     this.actionsMenu.reset();
-    this.unsubApp();
+    this.unsubApp?.();
     this.unsubApp = undefined;
     this.observers.length = 0;
     this.appEventObserverRemovers.forEach((remover) => remover());

--- a/app/assets/javascripts/views/abstract/pure_view_ctrl.ts
+++ b/app/assets/javascripts/views/abstract/pure_view_ctrl.ts
@@ -40,8 +40,8 @@ export class PureViewCtrl<P = CtrlProps, S = CtrlState> {
   }
 
   deinit(): void {
-    this.unsubApp();
-    this.unsubState();
+    this.unsubApp?.();
+    this.unsubState?.();
     for (const disposer of this.reactionDisposers) {
       disposer();
     }


### PR DESCRIPTION
- Poll every 10ms (does this sound like a reasonable interval?) to check if the current date is larger than the lock app date, and thus we need to lock the app. Before we used to poll every second, and if the app was visible we'd lock it. By reducing the polling interval we can avoid the app flashing before locking itself, and by checking if we need to lock even if the app isn't visible we're allowing the app to lock itself even when it is on the background
- Remove listeners for window blur and window focus and remove setTimer for locking app, since by reducing the polling interval I think we could rely on polling only

Not sure if this approach makes sense so as usual feedback is very welcome 🙂 