### PR TITLE
fix: the following is done:

### DIFF
--- a/app/assets/javascripts/components/AccountMenu/Authentication.tsx
+++ b/app/assets/javascripts/components/AccountMenu/Authentication.tsx
@@ -277,7 +277,7 @@ const Authentication = observer(({
               <div className="sk-panel-row" />
               <button
                 type="button"
-                className="sk-a info font-bold text-left p-0 hover:underline mr-1 ml-1"
+                className="sk-a info font-bold text-left p-0 cursor-pointer hover:underline mr-1 ml-1"
                 onClick={() => {
                   setShowAdvanced(!showAdvanced);
                 }}>

--- a/app/assets/javascripts/components/AccountMenu/ErrorReporting.tsx
+++ b/app/assets/javascripts/components/AccountMenu/ErrorReporting.tsx
@@ -56,8 +56,7 @@ const ErrorReporting = observer(({ appState }: Props) => {
       {errorReportingIdValue && (
         <>
           <p className="sk-p selectable">
-            Your random identifier is
-            strong {errorReportingIdValue}
+            Your random identifier is <span className="font-bold">{errorReportingIdValue}</span>
           </p>
           <p className="sk-p">
             Disabling error reporting will remove that identifier from your

--- a/app/assets/javascripts/components/AccountMenu/index.tsx
+++ b/app/assets/javascripts/components/AccountMenu/index.tsx
@@ -11,6 +11,7 @@ import Protections from '@/components/AccountMenu/Protections';
 import PasscodeLock from '@/components/AccountMenu/PasscodeLock';
 import DataBackup from '@/components/AccountMenu/DataBackup';
 import ErrorReporting from '@/components/AccountMenu/ErrorReporting';
+import { useEffect } from 'preact/hooks';
 
 type Props = {
   appState: AppState;
@@ -19,12 +20,24 @@ type Props = {
 
 const AccountMenu = observer(({ application, appState }: Props) => {
   const {
+    show: showAccountMenu,
     showLogin,
     showRegister,
+    setShowLogin,
+    setShowRegister,
     closeAccountMenu
   } = appState.accountMenu;
 
   const user = application.getUser();
+
+  useEffect(() => {
+    // Reset "Login" and "Registration" sections state when hiding account menu,
+    // so the next time account menu is opened these sections are closed
+    if (!showAccountMenu) {
+      setShowLogin(false);
+      setShowRegister(false);
+    }
+  }, [setShowLogin, setShowRegister, showAccountMenu]);
 
   return (
     <div className="sn-component">


### PR DESCRIPTION
- show cursor as pointer when hovering "Advanced Options"
- show error reporting identifier as bold text
- when closing account menu with opened "Sign in" form and then reopening account menu, don't show "Sign in" form