### PR TITLE
fix: empty panel above 'Install Custom Extension' panel

### DIFF
--- a/app/assets/javascripts/preferences/panes/Extensions.tsx
+++ b/app/assets/javascripts/preferences/panes/Extensions.tsx
@@ -66,13 +66,15 @@ export const Extensions: FunctionComponent<{
     setExtensions(loadExtensions(application));
   };
 
+  const visibleExtensions = extensions
+    .filter(extension => !['modal', 'rooms'].includes(extension.area));
+
   return (
     <PreferencesPane>
-      {extensions.length > 0 &&
+      {visibleExtensions.length > 0 &&
         <PreferencesGroup>
           {
-            extensions
-              .filter(extension => !['modal', 'rooms'].includes(extension.area))
+            visibleExtensions
               .sort((e1, e2) => e1.name.toLowerCase().localeCompare(e2.name.toLowerCase()))
               .map((extension, i) => (
                 <ExtensionItem


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5891646/139377247-afa2271f-904e-46ff-a572-1b268f26b1f6.png)

After:
![image](https://user-images.githubusercontent.com/5891646/139377288-183e557f-f00c-4bc4-b4a0-9b51dccaf0f9.png)

(Asana task: https://app.asana.com/0/1160981203938995/1201287063111826)