### PR TITLE
fix: break long extension url text when it exceeds container width

### DIFF
--- a/app/assets/javascripts/preferences/panes/extensions-segments/ConfirmCustomExtension.tsx
+++ b/app/assets/javascripts/preferences/panes/extensions-segments/ConfirmCustomExtension.tsx
@@ -49,7 +49,7 @@ export const ConfirmCustomExtension: FunctionComponent<{
         return (
           <>
             <Subtitle>{field.label}</Subtitle>
-            <Text>{field.value}</Text>
+            <Text className={'wrap'}>{field.value}</Text>
             <div className="min-h-2" />
           </>
         );


### PR DESCRIPTION
Internal link - https://app.asana.com/0/1200588672119490/1201366375943304