### PR TITLE
fix: note icons getting pushed by extra-long words

### DIFF
--- a/app/assets/javascripts/components/NotesListItem.tsx
+++ b/app/assets/javascripts/components/NotesListItem.tsx
@@ -93,8 +93,8 @@ export const NotesListItem: FunctionComponent<Props> = ({
         </div>
       )}
       <div className={`meta ${hideEditorIcon ? 'icon-hidden' : ''}`}>
-        <div className="name">
-          <div>{note.title}</div>
+        <div className="name-container">
+          <div className="name">{note.title}</div>
           <div className="flag-icons">
             {note.locked && (
               <span title="Editing Disabled">

--- a/app/assets/stylesheets/_notes.scss
+++ b/app/assets/stylesheets/_notes.scss
@@ -134,18 +134,24 @@
         padding-left: 1rem;
       }
 
-      .name {
+      .name-container {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         justify-content: space-between;
         font-weight: 600;
         font-size: 1rem;
         line-height: 1.3;
         overflow: hidden;
-        text-overflow: ellipsis;
+      }
+
+      .name {
+        word-break: break-all;
+        margin-right: 0.5rem;
       }
 
       .flag-icons {
+        padding: .135rem 0;
+
         &,
         & > * {
           display: flex;


### PR DESCRIPTION
[Internal link](https://app.asana.com/0/1201611182420182/1201738757752644/f)